### PR TITLE
Remove Wire and SPI from MARTHA_STM and BMP from nucleo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,6 @@ build_flags =
 lib_deps = 
 	adafruit/Adafruit LIS3MDL@^1.2.1
 	adafruit/Adafruit LSM6DS@^4.7.2
-	adafruit/Adafruit BMP3XX Library@^2.1.5
 	adafruit/Adafruit SPIFlash@^5.0.1
 
 [env:martha_stm]
@@ -34,8 +33,6 @@ build_flags =
 lib_deps = 
 	adafruit/Adafruit LIS3MDL@^1.2.1
 	adafruit/Adafruit LSM6DS@^4.7.2
-	Wire
-	SPI
 	arduino-libraries/SD@^1.2.4
 	adafruit/Adafruit SPIFlash@^5.0.1
 debug_tool = stlink


### PR DESCRIPTION
- Resolves #20 
- Cleans up extra dependencies which could conflict with the Adafruit libraries. 