### PR TITLE
fix: add clearInternalState after clearPLM when needed

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -35,6 +35,7 @@ void ping(std::queue<std::string> arguments, std::string& response) {
 
 void clearPostLaunchMode(std::queue<std::string> arguments, std::string& response) {
     dataSaver.clearPostLaunchMode();
+    dataSaver.clearInternalState();
     launchDetector.reset(); // fibo
     cmdLine.println("Cleared post launch mode, reboot the device to complete the reset.");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,6 +215,7 @@ void setup() {
   while (!Serial) delay(10);
   SerialSim::getInstance().begin(&Serial, &stateMachine); 
   dataSaver.clearPostLaunchMode(); // Clear plm for sim
+  dataSaver.clearInternalState();
   #endif
 
 }

--- a/test/test_datasaver_spi/test_DataSaverSPI.cpp
+++ b/test/test_datasaver_spi/test_DataSaverSPI.cpp
@@ -67,6 +67,7 @@ void test_data_saver_begin() {
 
 void test_save_data_point() {
     dataSaver.clearPostLaunchMode();
+    dataSaver.clearInternalState();
     DataPoint dp = {100, 50}; // Example DataPoint: timestamp = 100ms, value = 50
     unsigned long start_time = millis();
     TEST_ASSERT_EQUAL(0, dataSaver.saveDataPoint(dp, 1)); // 1 as name/ID
@@ -102,6 +103,7 @@ void test_flush_buffer_count(){
 void test_post_launch_mode() {
     unsigned long start_time = millis();
     dataSaver.clearPostLaunchMode();
+    dataSaver.clearInternalState();
 
     TEST_ASSERT_EQUAL(false, dataSaver.isPostLaunchMode());
     TEST_ASSERT_EQUAL(false, dataSaver.quickGetPostLaunchMode());
@@ -114,6 +116,7 @@ void test_post_launch_mode() {
     TEST_ASSERT_EQUAL(0, dataSaver.saveDataPoint(dp, 1));
     // Check post-launch flag persistence
     dataSaver.clearPostLaunchMode();
+    dataSaver.clearInternalState();
     TEST_ASSERT_EQUAL(false, dataSaver.isPostLaunchMode());
     Serial.printf("test_post_launch_mode execution time: %lu ms\n", millis() - start_time);
 }


### PR DESCRIPTION
Realized i did not make these changes for Martha 1.3. Need to add clearInternalstate after clearpostlaunchmode in most cases since clearplm no longer calls it.